### PR TITLE
Fix error handling

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,4 +1,6 @@
 Version History
 ---------------
+- 0.1.1 [2014-11-06]:
+ - Make Tornado 3.x compatible.
 - 0.1.0 [2014-10-14]
  - Initial release

--- a/sprockets/handlers/heartbeat/__init__.py
+++ b/sprockets/handlers/heartbeat/__init__.py
@@ -8,7 +8,7 @@ import logging
 
 from tornado.web import RequestHandler
 
-version_info = (0, 1, 0)
+version_info = (0, 1, 1)
 __version__ = '.'.join(str(v) for v in version_info)
 
 LOGGER = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ class HeartbeatHandler(RequestHandler):
         """Respond with the health of our service."""
         if not all(callback() for callback in callbacks):
             self.set_status(500)
-            self.write()
+            return
 
         self.set_status(204)
 


### PR DESCRIPTION
There was an unnecessary call to `RequestHandler.write` inside of the failure handling that was missing a required parameter.  This should really just set the status and return.
